### PR TITLE
fix: remove latest information from release file

### DIFF
--- a/internal/core/changelog/config.go
+++ b/internal/core/changelog/config.go
@@ -12,7 +12,6 @@ type IndexData struct {
 }
 
 type ReleaseData struct {
-	Latest       Spec
 	Changelog    Spec
 	FrontMatters string
 }
@@ -116,7 +115,6 @@ func (c Config) SaveToDisk(changelogs []Spec) error {
 
 	for i := range changelogs {
 		data := ReleaseData{
-			Latest:    changelogs[0],
 			Changelog: changelogs[i],
 		}
 
@@ -194,7 +192,6 @@ func (c Config) SaveIndexToDisk(changelogs []Spec) error {
 	}
 
 	data := IndexData{
-		Latest:     changelogs[0],
 		Changelogs: changelogs,
 	}
 
@@ -229,6 +226,7 @@ func (c Config) SaveIndexToDisk(changelogs []Spec) error {
 			}
 			data.Changelogs = shortChangelogs
 			data.Latest = shortChangelogs[0]
+			data.FrontMatters = ""
 
 			if err = toJsonFile(data, filepath.Join(c.Dir, indexFileName)); err != nil {
 				fmt.Printf("creating index json file %s: %v", filepath.Join(c.Dir, "index.json"), err)

--- a/internal/core/changelog/format_asciidoc.go
+++ b/internal/core/changelog/format_asciidoc.go
@@ -17,10 +17,6 @@ var (
 __{{ .Changelog.Author }} released this {{ .Changelog.PublishedAt }} - {{ .Changelog.Tag }}__
 {{ end }}
 
-{{ if ne .Changelog.Tag .Latest.Tag }}
-IMPORTANT: This changelog is not the latest one, please refer to {{ .Latest.Name }} for the latest changelog.
-{{ end }}
-
 === Description
 
 ---


### PR DESCRIPTION
After usage, it turns out that updating all previous release file are super noisy.
For example https://github.com/updatecli/website/pull/1357

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
make build test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
