### PR TITLE
fix: swap exit code between success with and without change

### DIFF
--- a/internal/core/result/changelog.go
+++ b/internal/core/result/changelog.go
@@ -22,9 +22,9 @@ type Changelog struct {
 
 func (c Changelog) ExitCode() int {
 	if len(c.Created) == 0 && len(c.Modified) == 0 {
-		return 1
+		return 0
 	}
-	return 0
+	return 1
 }
 
 // UpdateResult update the result with the current changelog information


### PR DESCRIPTION
While writing https://github.com/updatecli/website/pull/1438
I realize that it would make more sense to swap the two values